### PR TITLE
Add /etc/hosts file entry for the container's docker host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 
 COPY files/.bashrc /root
 COPY files/edit.json /usr/lib/node_modules/cloudcmd/node_modules/edward/json/
+COPY dxlenvironment /dxlenvironment
 
 ENV cloudcmd_contact false
 ENV cloudcmd_console false
@@ -24,4 +25,4 @@ ENV cloudcmd_terminal_path gritty
 
 EXPOSE 8000
 
-ENTRYPOINT ["cloudcmd"]
+ENTRYPOINT ["/dxlenvironment/startup.sh"]

--- a/dxlenvironment/startup.sh
+++ b/dxlenvironment/startup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DOCKER_HOSTNAME=dockerhost
+DOCKER_HOSTIP=$(ip route | sed -n 's/.*default via \([^ ]*\).*/\1/p')
+
+# Add entry for docker host to the /etc/hosts file
+if [ -n $DOCKER_HOSTIP ]; then
+    echo "Using docker host IP address ${DOCKER_HOSTIP}"
+    if ! grep -q $DOCKER_HOSTNAME /etc/hosts 2>/dev/null; then
+        echo -e "\n${DOCKER_HOSTIP} ${DOCKER_HOSTNAME}" >> /etc/hosts
+        if [ $? -ne 0 ]; then
+            echo "Failed to add docker host entry to /etc/hosts file" >&2
+        fi
+    fi
+else
+    echo "Unable to determine docker host IP address" >&2
+fi
+
+# Run cloud commander
+cloudcmd


### PR DESCRIPTION
This commit adds some startup logic which tries to determine what the IP address of the docker host is and adds an entry to the `/etc/hosts` file which associates that IP address with the name `dockerhost`. This is being done to allow for users to use a fixed host name when running shell commands which need to access ports being mapped from the docker host without having to write logic to determine the appropriate IP address themselves. Note that the logic assumes that the container's default network gateway IP address should be the same as the host's IP address on the docker NAT network.