### PR TITLE
Add support for persisting cloudcmd config and https

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,26 @@ FROM python:2.7-slim
 
 VOLUME ["/opendxl"]
 
+COPY opendxl-cloudcmd/package.json /opendxl-cloudcmd/
+
 RUN apt-get update \
     && apt-get install -y curl git unzip wget telnet \
     && curl -sL https://deb.nodesource.com/setup_8.x | /bin/bash - \
     && apt-get install -y nodejs build-essential \
-    && npm i cloudcmd -g \
-    && npm i gritty \
+    && cd /opendxl-cloudcmd \
+    && npm i \
+    && cd / \
     && apt-get remove -y --auto-remove build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip install sphinx dxlclient==4.0.0.416 dxlbootstrap==0.1.4
 
+COPY opendxl-cloudcmd/opendxl-cloudcmd.js /opendxl-cloudcmd/
+
 COPY files/.bashrc /root
-COPY files/edit.json /usr/lib/node_modules/cloudcmd/node_modules/edward/json/
+COPY files/edit.json /opendxl-cloudcmd/node_modules/edward/json/
 COPY dxlenvironment /dxlenvironment
 
-ENV cloudcmd_contact false
-ENV cloudcmd_console false
-ENV cloudcmd_one_panel_mode true
-ENV cloudcmd_terminal true
-ENV cloudcmd_terminal_path gritty
-
-EXPOSE 8000
+EXPOSE 9443
 
 ENTRYPOINT ["/dxlenvironment/startup.sh"]

--- a/dxlenvironment/config/webconsole/cloudcmd-https.json
+++ b/dxlenvironment/config/webconsole/cloudcmd-https.json
@@ -1,0 +1,5 @@
+{
+    "https": true,
+    "private_key": "/opendxl/keystore/cloudcmd.key",
+    "cert": "/opendxl/keystore/cloudcmd-bundle.crt"
+}

--- a/dxlenvironment/config/webconsole/cloudcmd.json
+++ b/dxlenvironment/config/webconsole/cloudcmd.json
@@ -1,0 +1,12 @@
+{
+    "port": 9443,
+    "auth": true,
+    "username": "admin",
+    "password": "b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86",
+    "algo": "sha512WithRSAEncryption",
+    "contact": false,
+    "console": false,
+    "onePanelMode": true,
+    "terminal": true,
+    "terminalPath": "gritty"
+}

--- a/dxlenvironment/config/webconsole/set-cloudcmd-creds
+++ b/dxlenvironment/config/webconsole/set-cloudcmd-creds
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+#
+# Command line utility which sets auth credentials for the cloud commander
+# web ui
+#
+
+import argparse
+import getpass
+import hashlib
+import json
+import os
+import sys
+from collections import OrderedDict
+
+
+# raw_input from Python 2 was renamed to input in Python 3. The snippet
+# below allows code to use input for both python versions
+try:
+    input = raw_input
+except NameError:
+    pass
+
+PASSWORD_HASH_ALGORITHM = "sha512WithRSAEncryption"
+
+
+def _error(message):
+    sys.stderr.write("{}, exiting\n".format(message))
+    exit(1)
+
+
+def _create_command_line_parser():
+    parser = argparse.ArgumentParser(
+        description="set auth credentials for the cloud commander web ui")
+    parser.add_argument(
+        "-d", "--disable-auth", action="store_true",
+        required=False,
+        help="disable authentication (auth is enabled by default)")
+    parser.add_argument(
+        "-c", "--config-file", metavar="FILE",
+        default="cloudcmd.json",
+        help="config file to update (default is 'cloudcmd.json')")
+    parser.add_argument(
+        "-n", "--no-credential-prompts", action="store_true",
+        required=False,
+        help="do not prompt for credentials (default is to prompt)")
+    parser.add_argument(
+        "-u", "--username", metavar="USERNAME",
+        required=False,
+        help="user name for authentication")
+    parser.add_argument(
+        "-p", "--password", metavar="PASSWORD",
+        required=False,
+        help="password for authentication")
+    return parser
+
+
+def _get_username(args, config, auth):
+    username_from_config = config.get("username", "")
+    if args.username:
+        return_value = args.username
+    elif auth and not args.no_credential_prompts:
+        username_prompt = "Enter username{}: ".format(
+            " [default = " + username_from_config + "]"
+            if username_from_config else "")
+        prompt_value = input(username_prompt)
+        return_value = prompt_value if prompt_value else username_from_config
+    else:
+        return_value = config.get("username", "")
+    return return_value
+
+
+def _hashed_password(password):
+    if password:
+        hashobj = hashlib.new(PASSWORD_HASH_ALGORITHM)
+        password_as_bytes = password if isinstance(password, bytes) \
+            else password.encode()
+        hashobj.update(password_as_bytes)
+        return_value = hashobj.hexdigest()
+    else:
+        return_value = ""
+    return return_value
+
+
+def _get_password_and_algo(args, config, auth):
+    if args.password:
+        password = _hashed_password(args.password)
+        algo = PASSWORD_HASH_ALGORITHM
+    elif auth and not args.no_credential_prompts:
+        while True:
+            password = getpass.getpass("Enter password:")
+            confirm_value = getpass.getpass("Confirm password:")
+            if password != confirm_value:
+                print("Values for password do not match. Try again.")
+            else:
+                break
+        password = _hashed_password(password)
+        algo = PASSWORD_HASH_ALGORITHM
+    else:
+        password = config.get("password", "")
+        algo = config.get("algo", PASSWORD_HASH_ALGORITHM)
+    return password, algo
+
+
+def main():
+    parser = _create_command_line_parser()
+    args = parser.parse_args()
+
+    if os.path.isfile(args.config_file):
+        if not os.access(args.config_file, os.W_OK):
+            _error("No permission to write config file {}".format(
+                args.config_file))
+        with open(args.config_file) as json_file:
+            config = json.load(json_file, object_pairs_hook=OrderedDict)
+    else:
+        config_dir = os.path.dirname(args.config_file)
+        if config_dir and not os.path.exists(config_dir):
+            try:
+                os.makedirs(config_dir)
+            except OSError as e:
+                _error("Unable to create config dir {}, reason: ({})".format(
+                    config_dir, e))
+        config = {}
+
+    auth = not args.disable_auth
+    username = _get_username(args, config, auth)
+    password, algo = _get_password_and_algo(args, config, auth)
+
+    config["auth"] = auth
+    config["username"] = username
+    config["password"] = password
+    config["algo"] = algo
+
+    try:
+        with open(args.config_file, 'w') as json_file:
+            json_text = json.dumps(config, indent=4)
+            json_file.write("{}\n".format(json_text))
+    except IOError as e:
+        _error("Unable to write config file {}, reason: ({})".format(
+            args.config_file, e))
+
+    print("Updated credentials in {}".format(args.config_file))
+    print("cloudcmd needs to be restarted for the changes to take effect")
+
+
+main()

--- a/dxlenvironment/startup.sh
+++ b/dxlenvironment/startup.sh
@@ -1,7 +1,59 @@
 #!/bin/bash
 
+DXLENVIRONMENT_DIR=/dxlenvironment
+DXLENVIRONMENT_CONFIG_DIR=$DXLENVIRONMENT_DIR/config
+DXLENVIRONMENT_WEB_CONSOLE_CONFIG_DIR=$DXLENVIRONMENT_CONFIG_DIR/webconsole
+DXLENVIRONMENT_CLOUDCMD_BASE_CONFIG_FILE=$DXLENVIRONMENT_WEB_CONSOLE_CONFIG_DIR/cloudcmd.json
+DXLENVIRONMENT_CLOUDCMD_HTTPS_CONFIG_FILE=$DXLENVIRONMENT_WEB_CONSOLE_CONFIG_DIR/cloudcmd-https.json
+DXLENVIRONMENT_CLOUDCMD_CREDS_SCRIPT=$DXLENVIRONMENT_WEB_CONSOLE_CONFIG_DIR/set-cloudcmd-creds
+
 DOCKER_HOSTNAME=dockerhost
 DOCKER_HOSTIP=$(ip route | sed -n 's/.*default via \([^ ]*\).*/\1/p')
+
+DVOL=/opendxl
+DVOL_CONFIG_DIR=$DVOL/config
+DVOL_WEB_CONSOLE_CONFIG_DIR=$DVOL_CONFIG_DIR/webconsole
+DVOL_CLOUDCMD_BASE_CONFIG_FILE=$DVOL_WEB_CONSOLE_CONFIG_DIR/cloudcmd.json
+DVOL_CLOUDCMD_HTTPS_CONFIG_FILE=$DVOL_WEB_CONSOLE_CONFIG_DIR/cloudcmd-https.json
+DVOL_CLOUDCMD_CREDS_SCRIPT=$DVOL_WEB_CONSOLE_CONFIG_DIR/set-cloudcmd-creds
+DVOL_KEYSTORE_DIR=$DVOL/keystore
+DVOL_ENVIRONMENT_CA_CERT_FILE=$DVOL_KEYSTORE_DIR/ca-environment.crt
+DVOL_ENVIRONMENT_CA_KEY_FILE=$DVOL_KEYSTORE_DIR/ca-environment.key
+DVOL_ENVIRONMENT_CA_CSR_FILE=$DVOL_KEYSTORE_DIR/ca-environment.csr
+DVOL_WEB_CONSOLE_CERT_FILE=$DVOL_KEYSTORE_DIR/cloudcmd.crt
+DVOL_WEB_CONSOLE_CERT_BUNDLE_FILE=$DVOL_KEYSTORE_DIR/cloudcmd-bundle.crt
+DVOL_WEB_CONSOLE_KEY_FILE=$DVOL_KEYSTORE_DIR/cloudcmd.key
+DVOL_WEB_CONSOLE_CSR_FILE=$DVOL_KEYSTORE_DIR/cloudcmd.csr
+DVOL_V3_EXT_FILE=$DVOL_KEYSTORE_DIR/v3.ext
+REQUIRED_CERT_FILES=($DVOL_WEB_CONSOLE_CERT_BUNDLE_FILE $DVOL_WEB_CONSOLE_KEY_FILE)
+
+CERT_PASS=OpenDxlEnvironment
+CERT_DAYS=3650
+
+#
+# Function that is invoked when the script fails.
+#
+# $1 - The message to display prior to exiting.
+#
+function fail() {
+    echo $1
+    echo "Exiting."
+    exit 1
+}
+
+#
+# Create directories
+#
+if [ ! -d $DVOL_KEYSTORE_DIR ]; then
+    echo "Creating keystore directory..."
+    mkdir -p $DVOL_KEYSTORE_DIR \
+        || { fail 'Error creating keystore directory.'; }
+fi
+if [ ! -d $DVOL_WEB_CONSOLE_CONFIG_DIR ]; then
+    echo "Creating web console config directory..."
+    mkdir -p $DVOL_WEB_CONSOLE_CONFIG_DIR \
+        || { fail 'Error creating web console config directory.'; }
+fi
 
 # Add entry for docker host to the /etc/hosts file
 if [ -n $DOCKER_HOSTIP ]; then
@@ -16,5 +68,94 @@ else
     echo "Unable to determine docker host IP address" >&2
 fi
 
-# Run cloud commander
-cloudcmd
+#
+# Check and possibly generate certificate information
+#
+
+# Check to see if any of the required cert files exist
+found_cert_file=false
+for f in "${REQUIRED_CERT_FILES[@]}"
+do
+    if [ -f $f ]; then
+        found_cert_file=true
+        break
+    fi
+done
+
+if [ $found_cert_file = true ]
+then
+    # At least one file exists, make sure they all exist
+    found_all_files=true
+    for f in "${REQUIRED_CERT_FILES[@]}"
+    do
+        if [ ! -f $f ]; then
+            found_all_files=false
+            echo "Required cert file not found: $f"
+        fi
+    done
+    if [ $found_all_files = false ]; then
+        fail 'Required cert files were not found.'
+    fi
+else
+    # No cert files exist, generate them.
+    echo "Generating certificate files..."
+
+    # Create Environment CA
+    openssl req -new -passout pass:"$CERT_PASS" \
+        -subj "/CN=OpenDxlEnvironmentCA" -x509 -days $CERT_DAYS \
+        -extensions v3_ca -keyout $DVOL_ENVIRONMENT_CA_KEY_FILE \
+        -out $DVOL_ENVIRONMENT_CA_CERT_FILE \
+        || { fail 'Error creating environment CA.'; }
+
+    # Create web console CSR
+    openssl req -out $DVOL_WEB_CONSOLE_CSR_FILE \
+        -subj "/CN=OpenDxlEnvironmentWebConsole" -new -newkey rsa:2048 -nodes \
+        -keyout $DVOL_WEB_CONSOLE_KEY_FILE \
+        || { fail 'Error generating web console CSR.'; }
+
+    # Create V3 extension file (CA is false)
+    echo "basicConstraints=CA:FALSE" > $DVOL_V3_EXT_FILE \
+        || { fail 'Error creating web console V3 extension file.'; }
+
+    # Sign the web console CSR
+    openssl x509 -req -passin pass:"$CERT_PASS" -in $DVOL_WEB_CONSOLE_CSR_FILE \
+        -CA $DVOL_ENVIRONMENT_CA_CERT_FILE \
+        -CAkey $DVOL_ENVIRONMENT_CA_KEY_FILE -CAcreateserial \
+        -out $DVOL_WEB_CONSOLE_CERT_FILE -days $CERT_DAYS \
+        -extfile $DVOL_V3_EXT_FILE \
+        || { fail 'Error signing web console CSR.'; }
+
+    # Concatenate web console and CA cert file into cert bundle
+    cp $DVOL_WEB_CONSOLE_CERT_FILE $DVOL_WEB_CONSOLE_CERT_BUNDLE_FILE \
+        || { fail 'Error copying web console cert into cert bundle.'; }
+    cat $DVOL_ENVIRONMENT_CA_CERT_FILE >> $DVOL_WEB_CONSOLE_CERT_BUNDLE_FILE \
+        || { fail 'Error appending environment CA cert into cert bundle.'; }
+
+    # Remove temporary files
+    rm -f $DVOL_KEYSTORE_DIR/*.csr
+    rm -f $DVOL_KEYSTORE_DIR/*.srl
+    rm -f $DVOL_V3_EXT_FILE
+fi
+
+#
+# Setup cloud commander configuration files
+#
+if [ ! -f $DVOL_CLOUDCMD_BASE_CONFIG_FILE ]; then
+    cp $DXLENVIRONMENT_CLOUDCMD_BASE_CONFIG_FILE $DVOL_CLOUDCMD_BASE_CONFIG_FILE
+fi
+if [ ! -f $DVOL_CLOUDCMD_HTTPS_CONFIG_FILE ]; then
+    cp $DXLENVIRONMENT_CLOUDCMD_HTTPS_CONFIG_FILE $DVOL_CLOUDCMD_HTTPS_CONFIG_FILE
+fi
+if [ ! -f $DVOL_CLOUDCMD_CREDS_SCRIPT ]; then
+    cp $DXLENVIRONMENT_CLOUDCMD_CREDS_SCRIPT $DVOL_CLOUDCMD_CREDS_SCRIPT
+fi
+
+#
+# Link the standard location cloudcmd expects the config file to be in to the
+# config file on the volume. This allows for any edits made to the config file
+# from the cloudcmd web ui to be updated in the file on the volume.
+#
+ln -sf $DVOL_CLOUDCMD_BASE_CONFIG_FILE $HOME/.cloudcmd.json
+
+# Run the OpenDXL cloud commander wrapper
+/opendxl-cloudcmd/opendxl-cloudcmd.js -c $DVOL_WEB_CONSOLE_CONFIG_DIR

--- a/opendxl-cloudcmd/opendxl-cloudcmd.js
+++ b/opendxl-cloudcmd/opendxl-cloudcmd.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Wrapper script for loading the cloudcmd app in an express web server,
+// under http or https depending upon configuration settings
+
+const CLOUDCMD_BASE_CONFIG = 'cloudcmd.json';
+const CLOUDCMD_HTTPS_CONFIG = 'cloudcmd-https.json';
+
+const cloudcmd = require('cloudcmd');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const express = require('express');
+const io = require('socket.io');
+const minimist = require('minimist');
+const path = require('path');
+
+const DEFAULT_CONFIG_DIR = '/opendxl/config/webconsole';
+
+const argv = process.argv;
+const args = minimist(argv.slice(2), {
+    string: [
+        'config-dir'
+    ],
+    boolean: [
+        'help'
+    ],
+    default: {
+        'config-dir': DEFAULT_CONFIG_DIR
+    },
+    alias: {
+        c: 'config-dir',
+        h: 'help'
+    },
+    unknown: (cmd) => {
+        exit('\'%s\' is not an opendxl-cloudcmd option. %s',
+            cmd, 'See \'opendxl-cloudcmd --help\'.');
+    }
+})
+
+function exit() {
+    console.error.apply(console, arguments);
+    process.exit(1);
+}
+
+function help() {
+    console.log('Usage: opendxl-cloudcmd [options]');
+    console.log('Options:');
+    console.log('  -h, --help        display this help and exit')
+    console.log('  -c, --config-dir  directory in which config files reside')
+    console.log('                      (default is \'%s\')', DEFAULT_CONFIG_DIR)
+}
+
+function adjustedPrefix(value) {
+    if (typeof(value) !== 'string')
+        return '';
+
+    if (value.length === 1)
+        return '';
+
+    if (value && !~value.indexOf('/'))
+        return '/' + value;
+
+    return value;
+}
+
+function loadConfigFile(fileName) {
+    let jsonText;
+    try {
+        jsonText = fs.readFileSync(fileName, 'utf-8');
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            console.log("Config file (%s) not found, using defaults",
+                fileName);
+            jsonText = '{}';
+        } else {
+            exit('Error reading config file (%s): %s, exiting...',
+                fileName, e);
+        }
+    }
+
+    let jsonObject;
+    try {
+        jsonObject = JSON.parse(jsonText);
+    } catch (e) {
+        exit('Error parsing JSON from config file (%s): %s, exiting...',
+            fileName, e);
+    }
+
+    return jsonObject;
+}
+
+function slurp(fileName, fileDescription) {
+    if (!fileName) {
+        exit('File name not configured for %s, exiting...',
+            fileDescription);
+    }
+
+    let fileContents;
+    try {
+        fileContents = fs.readFileSync(fileName, 'utf-8');
+    } catch (e) {
+        exit('Error reading %s file (%s): %s, exiting...',
+            fileDescription, fileName, e);
+    }
+    return fileContents;
+}
+
+function main() {
+    const baseCloudCmdConfig = loadConfigFile(path.join(args['config-dir'],
+        CLOUDCMD_BASE_CONFIG));
+    const httpsCloudCmdConfig = loadConfigFile(path.join(args['config-dir'],
+        CLOUDCMD_HTTPS_CONFIG));
+
+    const port = baseCloudCmdConfig['port'];
+    if (port < 0 || port > 65535)
+        exit('Invalid port (%s). %s. %s.', port,
+            'Port must be >= 0 and < 65536',
+            'For 0, an available port is chosen');
+
+    const ip = baseCloudCmdConfig['ip'] || '0.0.0.0';
+    const prefix = adjustedPrefix(baseCloudCmdConfig['prefix']);
+    const app = express();
+
+    let server;
+    let scheme;
+    if (httpsCloudCmdConfig['https']) {
+        scheme = 'https';
+        const privateKey = slurp(httpsCloudCmdConfig['private_key'],
+            'private key');
+        const certificate = slurp(httpsCloudCmdConfig['cert'], 'certificate');
+        const credentials = {key: privateKey, cert: certificate};
+        server = https.createServer(credentials, app);
+    } else {
+        scheme = 'http';
+        server = http.createServer(app);
+    }
+
+    app.use([cloudcmd({
+        socket: io(server, {
+            path: `${prefix}/socket.io`
+        }),
+        config: baseCloudCmdConfig
+    })]);
+
+    server.listen(port, ip, () => {
+        const host = baseCloudCmdConfig['ip'] || 'localhost';
+        const assignedPort = port || server.address().port;
+        const url = `${scheme}://${host}:${assignedPort}${prefix}/`;
+
+        console.log('url:', url);
+    });
+
+    server.on('error', error => {
+        exit('opendxl-cloudcmd server error: %s, exiting...',
+            error.message);
+    });
+}
+
+if (args.help)
+    help();
+else
+    main();

--- a/opendxl-cloudcmd/package.json
+++ b/opendxl-cloudcmd/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "opendxl-cloudcmd",
+    "version": "0.0.1",
+    "description": "Wrapper to cloudcmd which adds https server support",
+    "dependencies": {
+        "cloudcmd": "*",
+        "express": "*",
+        "gritty": "*",
+        "minimist": "*",
+        "socket.io": "*"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/opendxl/opendxl-environment"
+    },
+    "bin": {
+        "opendxl-cloudcmd": "opendxl-cloudcmd.js"
+    },
+    "license": "Apache-2.0"
+}


### PR DESCRIPTION
This PR adds the ability to persist cloudcmd configuration to a file, `cloudcmd.json`, on an external volume. This allows config changes to be preserved even after Docker containers are recycled.

The `cloudcmd.json` options are the same as those in the standard [~/.cloudcmd.json](http://cloudcmd.io/#config) file that cloudcmd supports. A package with preset defaults -- including ui `auth` enabled and the username set to `admin` and password to `password` -- is copied to the config volume if the file is not already present at startup.

Default settings which had previously been specified via environment variables in the Dockerfile previously --  -- e.g., `cloudcmd_contact` -- have been moved to the default `cloudcmd.json` file instead. Users would now have the ability to change the values for these settings in the config, if desired.

This PR also adds support for enabling https on the cloudcmd web server. https is the default but http can be configured through a `cloudcmd-https.json` config file. This is done via including a nodejs script which "bootstraps" the cloudcmd app into an express web server instance, with the desired http/https configuration being applied. The bootstrapping implementation follows the [Using as middleware](http://cloudcmd.io/#using-as-middleware) approach described in the cloudcmd documentation.

In support of the https configuration mode, the container startup script generates a private key and certificates on the volume, if they do not exist, and the resulting files are configured in the web server when https is enabled. 

cloudcmd assumes that the admin password is hashed as stored to its configuration file. The hashed password can be set through using the config widget in the web ui. For use in generating the appropriate
credentials offline, a `set-cloudcmd-creds` Python script can be run from the command line. Note that the server would need to be restarted after changing credentials in order for the changes to take effect.

npm dependencies for the bootstrap nodejs script are included in a `package.json` file. This allows for running `npm i` from the `opendxl-cloudcmd` subdirectory to install all of the nodejs dependencies which are needed for the app to be run locally -- which could be done outside of docker.

`node_modules` for both cloudcmd and gritty are now installed to a single subdirectory within the new local `opendxl-cloudcmd` package rather than being installed into the global `node_modules` directory (for cloudcmd) and a separate root-level directory (for gritty). This appears to allow for the docker images to be about 12 MB smaller than before due to npm being able to dedup files stored for common dependencies between the two.

One drawback of the current implementation of the bootstrap script is that it doesn't currently support overriding configuration data from environment variables like the `cloudcmd` script does. We could consider adding that in later if desired - e.g., for users that might want to protect the password in an an environment variable rather than storing it in hashed form in the config file.